### PR TITLE
feat: Implement login handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ A very special thanks to my Golang and Clean Arch mentor, [Helder](https://githu
 * [pgx](https://github.com/jackc/pgx) - For configuring and connecting a pool to a PostgreSQL database and running queries;
 * [Dockertest](https://github.com/ory/dockertest) - For running integration tests on temporary database containers;
 * [bcrypt](https://golang.org/x/crypto/bcrypt) - For hashing and comparing hashed secrets;
+* [jwt](github.com/golang-jwt/jwt/v4) - For signing and verifying JSON Web Tokens for authenticatioin;
 * [Logrus](https://github.com/sirupsen/logrus) - For logging. This library is used in the dockertest example. I haven't set up logging for the project, so I will decide later if this will actually be used.
 
 ## Testing the app
 
-I've implemented only the internal layers (entities and usecases) and repositories, so you can't actually run the app. However, you can test all the packages that have been created so far. To do so, clone the project:
+So far I've implemented the internal layers (entities and usecases), repositories and handlers (missing router and main), so you can't actually run the app. However, you can test all the packages that have been created so far. To do so, clone the project:
 
 ```shell
 git clone https://github.com/jpgsaraceni/suricate-bank.git
@@ -26,7 +27,7 @@ In your local project directory, install dependencies:
 go mod download
 ```
 
-Then run all unit and integration tests (you will need [Docker](https://www.docker.com/) installed. I had some trouble with permissions on Linux, [this](https://stackoverflow.com/questions/48568172/docker-sock-permission-denied) fixed it for me.):
+Then run all unit and integration tests (you will need [Docker](https://www.docker.com/) installed. I had some trouble with permissions on Linux, [this](https://stackoverflow.com/questions/48568172/docker-sock-permission-denied) fixed it for me):
 
 ```shell
 go test ./...

--- a/app/domain/entities/account/account.go
+++ b/app/domain/entities/account/account.go
@@ -77,3 +77,13 @@ func (id AccountId) String() string {
 	parsedToUUID := uuid.UUID(id)
 	return parsedToUUID.String()
 }
+
+func ParseAccountId(id string) (AccountId, error) {
+	accountId, err := uuid.Parse(id)
+
+	if err != nil {
+		return AccountId{}, err
+	}
+
+	return AccountId(accountId), nil
+}

--- a/app/domain/entities/account/repository.go
+++ b/app/domain/entities/account/repository.go
@@ -3,6 +3,7 @@ package account
 import (
 	"context"
 
+	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
 	"github.com/jpgsaraceni/suricate-bank/app/vos/money"
 )
 
@@ -11,6 +12,7 @@ type Repository interface {
 	GetBalance(ctx context.Context, id AccountId) (int, error)
 	Fetch(ctx context.Context) ([]Account, error)
 	GetById(ctx context.Context, id AccountId) (Account, error)
+	GetByCpf(ctx context.Context, cpf cpf.Cpf) (Account, error)
 	CreditAccount(ctx context.Context, id AccountId, amount money.Money) error
 	DebitAccount(ctx context.Context, id AccountId, amount money.Money) error
 }

--- a/app/domain/entities/account/repository_mock.go
+++ b/app/domain/entities/account/repository_mock.go
@@ -3,6 +3,7 @@ package account
 import (
 	"context"
 
+	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
 	"github.com/jpgsaraceni/suricate-bank/app/vos/money"
 )
 
@@ -11,6 +12,7 @@ type MockRepository struct {
 	OnGetBalance    func(ctx context.Context, id AccountId) (int, error)
 	OnFetch         func(ctx context.Context) ([]Account, error)
 	OnGetById       func(ctx context.Context, id AccountId) (Account, error)
+	OnGetByCpf      func(ctx context.Context, cpf cpf.Cpf) (Account, error)
 	OnCreditAccount func(ctx context.Context, id AccountId, amount money.Money) error
 	OnDebitAccount  func(ctx context.Context, id AccountId, amount money.Money) error
 }
@@ -31,6 +33,10 @@ func (mock MockRepository) Fetch(ctx context.Context) ([]Account, error) {
 
 func (mock MockRepository) GetById(ctx context.Context, id AccountId) (Account, error) {
 	return mock.OnGetById(ctx, id)
+}
+
+func (mock MockRepository) GetByCpf(ctx context.Context, cpf cpf.Cpf) (Account, error) {
+	return mock.OnGetByCpf(ctx, cpf)
 }
 
 func (mock MockRepository) CreditAccount(ctx context.Context, id AccountId, amount money.Money) error {

--- a/app/gateways/api/http/accounts/create.go
+++ b/app/gateways/api/http/accounts/create.go
@@ -72,13 +72,5 @@ func (h handler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdAccountPayload := schemas.CreatedAccountToResponse(createdAccount)
-
-	if err != nil {
-		response.InternalServerError(err).SendJSON()
-
-		return
-	}
-
-	response.Created(createdAccountPayload).SendJSON()
+	response.Created(schemas.CreatedAccountToResponse(createdAccount)).SendJSON()
 }

--- a/app/gateways/api/http/accounts/fetch.go
+++ b/app/gateways/api/http/accounts/fetch.go
@@ -18,13 +18,5 @@ func (h handler) Fetch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accountListResponse := schemas.AccountsToResponse(accountList)
-
-	if err != nil {
-		response.InternalServerError(err).SendJSON()
-
-		return
-	}
-
-	response.Ok(accountListResponse).SendJSON()
+	response.Ok(schemas.AccountsToResponse(accountList)).SendJSON()
 }

--- a/app/gateways/api/http/accounts/get_balance.go
+++ b/app/gateways/api/http/accounts/get_balance.go
@@ -39,15 +39,7 @@ func (h handler) GetBalance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	balanceResponse := schemas.BalanceToResponse(accountId, balance)
-
-	if err != nil {
-		response.InternalServerError(err).SendJSON()
-
-		return
-	}
-
-	response.Ok(balanceResponse).SendJSON()
+	response.Ok(schemas.BalanceToResponse(accountId, balance)).SendJSON()
 }
 
 func getAccountIdFromRequest(r *http.Request) (account.AccountId, error) {

--- a/app/gateways/api/http/login/handler.go
+++ b/app/gateways/api/http/login/handler.go
@@ -1,0 +1,19 @@
+package loginroute
+
+import (
+	"net/http"
+
+	"github.com/jpgsaraceni/suricate-bank/app/services/auth"
+)
+
+type handler struct {
+	service auth.Service
+}
+
+type Handler interface {
+	Login(w http.ResponseWriter, r *http.Request)
+}
+
+func NewHandler(s auth.Service) Handler {
+	return &handler{service: s}
+}

--- a/app/gateways/api/http/login/login.go
+++ b/app/gateways/api/http/login/login.go
@@ -24,7 +24,7 @@ func (h handler) Login(w http.ResponseWriter, r *http.Request) {
 	account, err := h.service.Authenticate(r.Context(), loginRequest.Cpf, loginRequest.Secret)
 
 	if errors.Is(err, auth.ErrCredentials) {
-		response.BadRequest(responses.ErrCredentials).SendJSON()
+		response.Unauthorized(responses.ErrCredentials).SendJSON()
 
 		return
 	}

--- a/app/gateways/api/http/login/login.go
+++ b/app/gateways/api/http/login/login.go
@@ -1,0 +1,23 @@
+package loginroute
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jpgsaraceni/suricate-bank/app/gateways/api/http/responses"
+	"github.com/jpgsaraceni/suricate-bank/app/gateways/api/http/schemas"
+)
+
+func (h handler) Login(w http.ResponseWriter, r *http.Request) {
+	response := responses.NewResponse(w)
+
+	var loginRequest schemas.LoginRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&loginRequest); err != nil {
+		response.BadRequest(responses.ErrInvalidRequestPayload).SendJSON()
+
+		return
+	}
+
+	// TODO: check cpf, call authenticate service and write response
+}

--- a/app/gateways/api/http/login/login.go
+++ b/app/gateways/api/http/login/login.go
@@ -2,10 +2,12 @@ package loginroute
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/jpgsaraceni/suricate-bank/app/gateways/api/http/responses"
 	"github.com/jpgsaraceni/suricate-bank/app/gateways/api/http/schemas"
+	"github.com/jpgsaraceni/suricate-bank/app/services/auth"
 )
 
 func (h handler) Login(w http.ResponseWriter, r *http.Request) {
@@ -19,5 +21,19 @@ func (h handler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: check cpf, call authenticate service and write response
+	account, err := h.service.Authenticate(r.Context(), loginRequest.Cpf, loginRequest.Secret)
+
+	if errors.Is(err, auth.ErrCredentials) {
+		response.BadRequest(responses.ErrCredentials).SendJSON()
+
+		return
+	}
+
+	if err != nil {
+		response.InternalServerError(err).SendJSON()
+
+		return
+	}
+
+	response.Ok(schemas.LoginToResponse(account)).SendJSON()
 }

--- a/app/gateways/api/http/login/login_test.go
+++ b/app/gateways/api/http/login/login_test.go
@@ -1,0 +1,1 @@
+package loginroute

--- a/app/gateways/api/http/login/login_test.go
+++ b/app/gateways/api/http/login/login_test.go
@@ -77,7 +77,7 @@ func TestCreate(t *testing.T) {
 					return "", auth.ErrCredentials
 				},
 			},
-			expectedStatus:  400,
+			expectedStatus:  401,
 			expectedPayload: map[string]interface{}{"title": responses.ErrCredentials.Payload.Message},
 		},
 		{

--- a/app/gateways/api/http/login/login_test.go
+++ b/app/gateways/api/http/login/login_test.go
@@ -1,1 +1,148 @@
 package loginroute
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+	"github.com/jpgsaraceni/suricate-bank/app/gateways/api/http/responses"
+	"github.com/jpgsaraceni/suricate-bank/app/services/auth"
+	"github.com/jpgsaraceni/suricate-bank/app/vos/token"
+)
+
+func TestCreate(t *testing.T) {
+	t.Parallel()
+
+	type httpIO struct {
+		r *http.Request
+		w http.ResponseWriter
+	}
+
+	type testCase struct {
+		name            string
+		service         auth.Service
+		httpIO          httpIO
+		expectedStatus  int
+		expectedPayload interface{}
+	}
+
+	var testId = account.AccountId(uuid.New())
+
+	testCases := []testCase{
+		{
+			name: "successfully login",
+			httpIO: httpIO{
+				r: func() *http.Request {
+					return httptest.NewRequest(
+						http.MethodPost,
+						"/accounts",
+						bytes.NewReader([]byte(`{"Cpf":"22061446035", "Secret": "123456"}`)))
+				}(),
+				w: httptest.NewRecorder(),
+			},
+			service: auth.MockService{
+				OnAuthenticate: func(ctx context.Context, cpfInput, secret string) (string, error) {
+					jwt, _ := token.Sign(testId)
+					return jwt.Value(), nil
+				},
+			},
+			expectedStatus: 200,
+			expectedPayload: map[string]interface{}{
+				"token": func() string {
+					jwt, _ := token.Sign(testId)
+					return jwt.Value()
+				}(),
+			},
+		},
+		{
+			name: "fail login invalid credentials",
+			httpIO: httpIO{
+				r: func() *http.Request {
+					return httptest.NewRequest(
+						http.MethodPost,
+						"/accounts",
+						bytes.NewReader([]byte(`{"Cpf":"2206144605", "Secret": "123456"}`)))
+				}(),
+				w: httptest.NewRecorder(),
+			},
+			service: auth.MockService{
+				OnAuthenticate: func(ctx context.Context, cpfInput, secret string) (string, error) {
+					return "", auth.ErrCredentials
+				},
+			},
+			expectedStatus:  400,
+			expectedPayload: map[string]interface{}{"title": responses.ErrCredentials.Payload.Message},
+		},
+		{
+			name: "respond 400 to invalid request payload",
+			httpIO: httpIO{
+				r: func() *http.Request {
+					return httptest.NewRequest(
+						http.MethodPost,
+						"/accounts",
+						bytes.NewReader([]byte(`Not what the server expects`)))
+				}(),
+				w: httptest.NewRecorder(),
+			},
+			expectedStatus:  400,
+			expectedPayload: map[string]interface{}{"title": responses.ErrInvalidRequestPayload.Payload.Message},
+		},
+		{
+			name: "fail login service error",
+			httpIO: httpIO{
+				r: func() *http.Request {
+					return httptest.NewRequest(
+						http.MethodPost,
+						"/accounts",
+						bytes.NewReader([]byte(`{"Cpf":"22061446035", "Secret": "123456"}`)))
+				}(),
+				w: httptest.NewRecorder(),
+			},
+			service: auth.MockService{
+				OnAuthenticate: func(ctx context.Context, cpfInput, secret string) (string, error) {
+					return "", auth.ErrSignToken
+				},
+			},
+			expectedStatus:  500,
+			expectedPayload: map[string]interface{}{"title": responses.ErrInternalServerError.Message},
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewHandler(tt.service)
+
+			h.Login(tt.httpIO.w, tt.httpIO.r)
+
+			recorder, ok := tt.httpIO.w.(*httptest.ResponseRecorder)
+			if !ok {
+				t.Errorf("Error getting ResponseRecorder")
+			}
+
+			if statusCode := recorder.Code; statusCode != tt.expectedStatus {
+				t.Errorf("got status code %d expected %d", statusCode, tt.expectedStatus)
+			}
+
+			var got map[string]interface{}
+			err := json.NewDecoder(recorder.Body).Decode(&got)
+
+			if err != nil {
+				t.Fatalf("failed to decode response body: %s", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.expectedPayload) {
+				t.Fatalf("got response body: %s, expected %s", got, tt.expectedPayload)
+			}
+		})
+	}
+}

--- a/app/gateways/api/http/responses/payloads.go
+++ b/app/gateways/api/http/responses/payloads.go
@@ -55,4 +55,10 @@ var (
 		Err:     errors.New("account not found"),
 		Payload: ErrorPayload{Message: "Account not found"},
 	}
+
+	// login errors
+	ErrCredentials = Error{
+		Err:     errors.New("cpf or secret do not match"),
+		Payload: ErrorPayload{Message: "Incorrect CPF or password"},
+	}
 )

--- a/app/gateways/api/http/responses/responses.go
+++ b/app/gateways/api/http/responses/responses.go
@@ -29,6 +29,13 @@ func (r Response) BadRequest(err Error) Response {
 	return r
 }
 
+func (r Response) Unauthorized(err Error) Response {
+	r.Status = http.StatusUnauthorized
+	r.Error = err.Err
+	r.Payload = err.Payload
+	return r
+}
+
 func (r Response) NotFound(err Error) Response {
 	r.Status = http.StatusNotFound
 	r.Error = err.Err

--- a/app/gateways/api/http/schemas/login.go
+++ b/app/gateways/api/http/schemas/login.go
@@ -1,0 +1,20 @@
+package schemas
+
+import "github.com/jpgsaraceni/suricate-bank/app/vos/token"
+
+type LoginRequest struct {
+	Cpf    string `json:"cpf"`
+	Secret string `json:"secret"`
+}
+
+type LoginResponse struct {
+	Token string `json:"token"`
+}
+
+func LoginToResponse(token token.Jwt) LoginResponse {
+	return LoginResponse{
+		Token: token.Value(),
+	}
+}
+
+// TODO: create login schemas

--- a/app/gateways/api/http/schemas/login.go
+++ b/app/gateways/api/http/schemas/login.go
@@ -1,7 +1,5 @@
 package schemas
 
-import "github.com/jpgsaraceni/suricate-bank/app/vos/token"
-
 type LoginRequest struct {
 	Cpf    string `json:"cpf"`
 	Secret string `json:"secret"`
@@ -11,8 +9,8 @@ type LoginResponse struct {
 	Token string `json:"token"`
 }
 
-func LoginToResponse(token token.Jwt) LoginResponse {
+func LoginToResponse(token string) LoginResponse {
 	return LoginResponse{
-		Token: token.Value(),
+		Token: token,
 	}
 }

--- a/app/gateways/api/http/schemas/login.go
+++ b/app/gateways/api/http/schemas/login.go
@@ -16,5 +16,3 @@ func LoginToResponse(token token.Jwt) LoginResponse {
 		Token: token.Value(),
 	}
 }
-
-// TODO: create login schemas

--- a/app/gateways/db/postgres/accounts/errors.go
+++ b/app/gateways/db/postgres/accounts/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrEmptyFetch       = errors.New("fetch returned empty")
 	ErrBalanceUnchanged = errors.New("debit failed because amount to debit is greater than balance")
 	ErrCpfAlreadyExists = errors.New("cpf already exists in db")
+	ErrCpfNotFound      = errors.New("cpf does not exist in db")
 )

--- a/app/gateways/db/postgres/accounts/get_by_cpf.go
+++ b/app/gateways/db/postgres/accounts/get_by_cpf.go
@@ -25,7 +25,7 @@ func (r Repository) GetByCpf(ctx context.Context, cpf cpf.Cpf) (account.Account,
 
 	var accountReturned account.Account
 
-	row := r.pool.QueryRow(ctx, query, cpf)
+	row := r.pool.QueryRow(ctx, query, cpf.Value())
 
 	err := row.Scan(
 		&accountReturned.Id,

--- a/app/gateways/db/postgres/accounts/get_by_cpf.go
+++ b/app/gateways/db/postgres/accounts/get_by_cpf.go
@@ -1,0 +1,50 @@
+package accountspg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
+)
+
+func (r Repository) GetByCpf(ctx context.Context, cpf cpf.Cpf) (account.Account, error) {
+	const query = `
+		SELECT 
+			id,
+			name,
+			cpf,
+			secret,
+			balance,
+			created_at
+		FROM accounts
+		WHERE cpf = $1;
+	`
+
+	var accountReturned account.Account
+
+	row := r.pool.QueryRow(ctx, query, cpf)
+
+	err := row.Scan(
+		&accountReturned.Id,
+		&accountReturned.Name,
+		&accountReturned.Cpf,
+		&accountReturned.Secret,
+		&accountReturned.Balance,
+		&accountReturned.CreatedAt,
+	)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+
+		return account.Account{}, ErrCpfNotFound
+	}
+
+	if err != nil {
+
+		return account.Account{}, fmt.Errorf("%w: %s", ErrQuery, err.Error())
+	}
+
+	return accountReturned, nil
+}

--- a/app/gateways/db/postgres/accounts/get_by_cpf_test.go
+++ b/app/gateways/db/postgres/accounts/get_by_cpf_test.go
@@ -1,3 +1,87 @@
 package accountspg
 
-// TODO: write tests
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+	"github.com/jpgsaraceni/suricate-bank/app/gateways/db/postgres/postgrestest"
+	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
+)
+
+func TestGetByCpf(t *testing.T) {
+	t.Parallel()
+
+	testPool, tearDown := postgrestest.GetTestPool()
+	testRepo := NewRepository(testPool)
+
+	t.Cleanup(tearDown)
+
+	type testCase struct {
+		name            string
+		runBefore       func() error
+		cpf             cpf.Cpf
+		expectedAccount account.Account
+		err             error
+	}
+
+	var (
+		testId  = account.AccountId(uuid.New())
+		testCpf = cpf.Random()
+	)
+
+	testCases := []testCase{
+		{
+			name: "successfully get an account",
+			runBefore: func() error {
+				return createTestAccount(
+					testPool,
+					testId,
+					testCpf.Value(),
+					0,
+				)
+			},
+			cpf: testCpf,
+			expectedAccount: account.Account{
+				Id:        testId,
+				Name:      "nice name",
+				Cpf:       testCpf,
+				Secret:    testHash,
+				CreatedAt: testTime,
+			},
+		},
+		{
+			name:            "fail to get an inexixtent account",
+			cpf:             cpf.Random(),
+			expectedAccount: account.Account{},
+			err:             ErrCpfNotFound,
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.runBefore != nil {
+				err := tt.runBefore()
+
+				if err != nil {
+					t.Fatalf("runBefore() failed: %s", err)
+				}
+			}
+
+			gotAccount, err := testRepo.GetByCpf(testContext, tt.cpf)
+
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("got error: %s expected error: %s", err, tt.err)
+			}
+
+			if !reflect.DeepEqual(gotAccount, tt.expectedAccount) {
+				t.Fatalf("got %v expected %v", gotAccount, tt.expectedAccount)
+			}
+		})
+	}
+}

--- a/app/gateways/db/postgres/accounts/get_by_cpf_test.go
+++ b/app/gateways/db/postgres/accounts/get_by_cpf_test.go
@@ -1,0 +1,3 @@
+package accountspg
+
+// TODO: write tests

--- a/app/services/auth/auth.go
+++ b/app/services/auth/auth.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
 )
@@ -12,14 +12,14 @@ func (s service) Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (
 
 	if err != nil {
 
-		return "", errors.New("inexistent cpf") // TODO: create error variable
+		return "", fmt.Errorf("%w: %s", ErrInexistentCpf, err)
 	}
 
 	if !account.Secret.Compare(secret) {
 
-		return "", errors.New("wrong password") // TODO: create error variable
+		return "", fmt.Errorf("%w: %s", ErrWrongPassword, err)
 	}
 
-	// generate token using accountId
+	// TODO: generate token using accountId
 	return "", nil
 }

--- a/app/services/auth/auth.go
+++ b/app/services/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
+	"github.com/jpgsaraceni/suricate-bank/app/vos/token"
 )
 
 func (s service) Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (string, error) {
@@ -20,6 +21,12 @@ func (s service) Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (
 		return "", fmt.Errorf("%w: %s", ErrWrongPassword, err)
 	}
 
-	// TODO: generate token using accountId
-	return "", nil
+	jwt, err := token.Sign(account.Id)
+
+	if err != nil {
+
+		return "", fmt.Errorf("%w: %s", ErrSignToken, err)
+	}
+
+	return jwt.Value(), nil
 }

--- a/app/services/auth/auth.go
+++ b/app/services/auth/auth.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
+)
+
+func (s service) Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (string, error) {
+	account, err := s.repository.GetByCpf(ctx, cpf)
+
+	if err != nil {
+
+		return "", errors.New("inexistent cpf") // TODO: create error variable
+	}
+
+	if !account.Secret.Compare(secret) {
+
+		return "", errors.New("wrong password") // TODO: create error variable
+	}
+
+	// generate token using accountId
+	return "", nil
+}

--- a/app/services/auth/auth.go
+++ b/app/services/auth/auth.go
@@ -8,17 +8,24 @@ import (
 	"github.com/jpgsaraceni/suricate-bank/app/vos/token"
 )
 
-func (s service) Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (string, error) {
-	account, err := s.repository.GetByCpf(ctx, cpf)
+func (s service) Authenticate(ctx context.Context, cpfInput string, secret string) (string, error) {
+	validatedCpf, err := cpf.NewCpf(cpfInput)
 
 	if err != nil {
 
-		return "", fmt.Errorf("%w: %s", ErrInexistentCpf, err)
+		return "", fmt.Errorf("%w: %s", ErrCredentials, err)
+	}
+
+	account, err := s.repository.GetByCpf(ctx, validatedCpf)
+
+	if err != nil {
+
+		return "", fmt.Errorf("%w: %s", ErrCredentials, err)
 	}
 
 	if !account.Secret.Compare(secret) {
 
-		return "", fmt.Errorf("%w: %s", ErrWrongPassword, err)
+		return "", fmt.Errorf("%w: %s", ErrCredentials, err)
 	}
 
 	jwt, err := token.Sign(account.Id)

--- a/app/services/auth/auth_test.go
+++ b/app/services/auth/auth_test.go
@@ -58,7 +58,7 @@ func TestAuthenticate(t *testing.T) {
 			name: "fail to authenticate request with inexistent cpf",
 			repository: account.MockRepository{
 				OnGetByCpf: func(ctx context.Context, cpf cpf.Cpf) (account.Account, error) {
-					return account.Account{}, ErrInexistentCpf
+					return account.Account{}, ErrCredentials
 				},
 			},
 			args: args{
@@ -66,7 +66,7 @@ func TestAuthenticate(t *testing.T) {
 				secret: "123456",
 			},
 			want: account.AccountId{},
-			err:  ErrInexistentCpf,
+			err:  ErrCredentials,
 		},
 		{
 			name: "fail to authenticate request with wrong password",
@@ -84,7 +84,7 @@ func TestAuthenticate(t *testing.T) {
 				secret: "12345",
 			},
 			want: account.AccountId{},
-			err:  ErrWrongPassword,
+			err:  ErrCredentials,
 		},
 	}
 
@@ -95,7 +95,7 @@ func TestAuthenticate(t *testing.T) {
 
 			s := service{tt.repository}
 
-			gotToken, err := s.Authenticate(context.Background(), tt.args.cpf, tt.args.secret)
+			gotToken, err := s.Authenticate(context.Background(), tt.args.cpf.Value(), tt.args.secret)
 
 			if !errors.Is(err, tt.err) {
 				t.Fatalf("got %s expected %s", err, tt.err)

--- a/app/services/auth/auth_test.go
+++ b/app/services/auth/auth_test.go
@@ -1,3 +1,111 @@
 package auth
 
-//TODO: escrever testes
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
+	"github.com/jpgsaraceni/suricate-bank/app/vos/hash"
+	"github.com/jpgsaraceni/suricate-bank/app/vos/token"
+)
+
+func TestAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		cpf    cpf.Cpf
+		secret string
+	}
+
+	type testCase struct {
+		name       string
+		repository account.Repository
+		args       args
+		want       account.AccountId
+		err        error
+	}
+
+	var (
+		testId        = account.AccountId(uuid.New())
+		testCpf       = cpf.Random()
+		testSecret, _ = hash.NewHash("123456")
+	)
+
+	testCases := []testCase{
+		{
+			name: "successfully authenticate request",
+			repository: account.MockRepository{
+				OnGetByCpf: func(ctx context.Context, cpf cpf.Cpf) (account.Account, error) {
+					return account.Account{
+						Id:     testId,
+						Cpf:    testCpf,
+						Secret: testSecret,
+					}, nil
+				},
+			},
+			args: args{
+				cpf:    testCpf,
+				secret: "123456",
+			},
+			want: testId,
+		},
+		{
+			name: "fail to authenticate request with inexistent cpf",
+			repository: account.MockRepository{
+				OnGetByCpf: func(ctx context.Context, cpf cpf.Cpf) (account.Account, error) {
+					return account.Account{}, ErrInexistentCpf
+				},
+			},
+			args: args{
+				cpf:    testCpf,
+				secret: "123456",
+			},
+			want: account.AccountId{},
+			err:  ErrInexistentCpf,
+		},
+		{
+			name: "fail to authenticate request with wrong password",
+			repository: account.MockRepository{
+				OnGetByCpf: func(ctx context.Context, cpf cpf.Cpf) (account.Account, error) {
+					return account.Account{
+						Id:     testId,
+						Cpf:    testCpf,
+						Secret: testSecret,
+					}, nil
+				},
+			},
+			args: args{
+				cpf:    testCpf,
+				secret: "12345",
+			},
+			want: account.AccountId{},
+			err:  ErrWrongPassword,
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := service{tt.repository}
+
+			gotToken, err := s.Authenticate(context.Background(), tt.args.cpf, tt.args.secret)
+
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("got %s expected %s", err, tt.err)
+			}
+
+			gotId, _ := token.Verify(gotToken)
+
+			if !reflect.DeepEqual(gotId, tt.want) {
+				t.Errorf("got %v expected %v", gotId, tt.want)
+			}
+		})
+	}
+}

--- a/app/services/auth/auth_test.go
+++ b/app/services/auth/auth_test.go
@@ -1,0 +1,3 @@
+package auth
+
+//TODO: escrever testes

--- a/app/services/auth/errors.go
+++ b/app/services/auth/errors.go
@@ -1,0 +1,8 @@
+package auth
+
+import "errors"
+
+var (
+	ErrInexistentCpf = errors.New("inexistent cpf")
+	ErrWrongPassword = errors.New("wrong password")
+)

--- a/app/services/auth/errors.go
+++ b/app/services/auth/errors.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	ErrInexistentCpf = errors.New("inexistent cpf")
 	ErrWrongPassword = errors.New("wrong password")
+	ErrSignToken     = errors.New("failed to sign jwt")
 )

--- a/app/services/auth/errors.go
+++ b/app/services/auth/errors.go
@@ -3,7 +3,6 @@ package auth
 import "errors"
 
 var (
-	ErrInexistentCpf = errors.New("inexistent cpf")
-	ErrWrongPassword = errors.New("wrong password")
-	ErrSignToken     = errors.New("failed to sign jwt")
+	ErrCredentials = errors.New("wrong password or cpf")
+	ErrSignToken   = errors.New("failed to sign jwt")
 )

--- a/app/services/auth/service.go
+++ b/app/services/auth/service.go
@@ -1,0 +1,23 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
+)
+
+// usecase calls Repository to be used in all methods of this package.
+type service struct {
+	repository account.Repository
+}
+
+type Service interface {
+	Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (string, error) // TODO: check cpf here?
+}
+
+func NewService(r account.Repository) Service {
+	return &service{
+		repository: r,
+	}
+}

--- a/app/services/auth/service.go
+++ b/app/services/auth/service.go
@@ -4,16 +4,15 @@ import (
 	"context"
 
 	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
-	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
 )
 
-// usecase calls Repository to be used in all methods of this package.
+// service calls Repository to be used in all methods of this package.
 type service struct {
 	repository account.Repository
 }
 
 type Service interface {
-	Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (string, error) // TODO: check cpf here?
+	Authenticate(ctx context.Context, cpfInput string, secret string) (string, error)
 }
 
 func NewService(r account.Repository) Service {

--- a/app/services/auth/service_mock.go
+++ b/app/services/auth/service_mock.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
+)
+
+type MockService struct {
+	OnAuthenticate func(ctx context.Context, cpf cpf.Cpf, secret string) (string, error)
+}
+
+var _ Service = (*MockService)(nil)
+
+func (mock MockService) Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (string, error) {
+	return mock.OnAuthenticate(ctx, cpf, secret)
+}

--- a/app/services/auth/service_mock.go
+++ b/app/services/auth/service_mock.go
@@ -2,16 +2,14 @@ package auth
 
 import (
 	"context"
-
-	"github.com/jpgsaraceni/suricate-bank/app/vos/cpf"
 )
 
 type MockService struct {
-	OnAuthenticate func(ctx context.Context, cpf cpf.Cpf, secret string) (string, error)
+	OnAuthenticate func(ctx context.Context, cpfInput string, secret string) (string, error)
 }
 
 var _ Service = (*MockService)(nil)
 
-func (mock MockService) Authenticate(ctx context.Context, cpf cpf.Cpf, secret string) (string, error) {
-	return mock.OnAuthenticate(ctx, cpf, secret)
+func (mock MockService) Authenticate(ctx context.Context, cpfInput string, secret string) (string, error) {
+	return mock.OnAuthenticate(ctx, cpfInput, secret)
 }

--- a/app/vos/token/token.go
+++ b/app/vos/token/token.go
@@ -1,18 +1,55 @@
 package token
 
-import "github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
 
-// receive accountId and return token
-// receive token and return accountId
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/joho/godotenv"
+
+	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+)
+
+var ErrSignJWT = errors.New("failed to sign jwt")
 
 type Jwt struct {
 	token string
 }
 
-func GenerateJWT(accountId account.AccountId) Jwt {
-	return Jwt{token: ""} // TODO: implement jwt
-}
-
 func (j Jwt) Value() string {
 	return j.token
+}
+
+type jwtClaimsSchema struct {
+	AccountId string `json:"account_id"`
+	jwt.RegisteredClaims
+}
+
+func Sign(accountId account.AccountId) (Jwt, error) {
+
+	claims := jwtClaimsSchema{
+		accountId.String(),
+		jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 30)),
+			Issuer:    "suricate bank",
+		},
+	}
+
+	unsignedToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	signedToken, err := unsignedToken.SignedString(loadSecret())
+
+	if err != nil {
+
+		return Jwt{}, fmt.Errorf("%w: %s", ErrSignJWT, err)
+	}
+
+	return Jwt{token: signedToken}, nil
+}
+
+func loadSecret() []byte {
+	godotenv.Load()
+	return []byte(os.Getenv("JWT_SECRET"))
 }

--- a/app/vos/token/token.go
+++ b/app/vos/token/token.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/joho/godotenv"
 
 	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
 )
@@ -50,6 +50,9 @@ func Sign(accountId account.AccountId) (Jwt, error) {
 }
 
 func loadSecret() []byte {
-	godotenv.Load()
-	return []byte(os.Getenv("JWT_SECRET"))
+	secret := []byte(os.Getenv("JWT_SECRET"))
+	if reflect.DeepEqual(secret, []byte("")) {
+		return []byte("test_secret")
+	}
+	return secret
 }

--- a/app/vos/token/token.go
+++ b/app/vos/token/token.go
@@ -1,0 +1,18 @@
+package token
+
+import "github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+
+// receive accountId and return token
+// receive token and return accountId
+
+type Jwt struct {
+	token string
+}
+
+func GenerateJWT(accountId account.AccountId) Jwt {
+	return Jwt{token: ""} // TODO: implement jwt
+}
+
+func (j Jwt) Value() string {
+	return j.token
+}

--- a/app/vos/token/token.go
+++ b/app/vos/token/token.go
@@ -55,8 +55,8 @@ func Sign(accountId account.AccountId) (Jwt, error) {
 	return Jwt{token: signedToken}, nil
 }
 
-func (j Jwt) Verify() (account.AccountId, error) {
-	token, err := jwt.ParseWithClaims(j.token, &jwtClaimsSchema{}, func(token *jwt.Token) (interface{}, error) {
+func Verify(tokenString string) (account.AccountId, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &jwtClaimsSchema{}, func(token *jwt.Token) (interface{}, error) {
 		return loadSecret(), nil
 	})
 

--- a/app/vos/token/token_test.go
+++ b/app/vos/token/token_test.go
@@ -1,3 +1,62 @@
 package token
 
-//TODO: escrever testes
+import (
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+
+	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+)
+
+func TestGenerateJWT(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name string
+		id   account.AccountId
+		want string
+		err  error
+	}
+
+	var testId = account.AccountId(uuid.New())
+
+	testCases := []testCase{
+		{
+			name: "successfully generate token",
+			id:   testId,
+			want: testId.String(),
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			generatedToken, err := Sign(tt.id)
+
+			if !errors.Is(err, tt.err) {
+				t.Errorf("got error %s expected error %s", err, tt.err)
+			}
+
+			parsedToken, _ := jwt.ParseWithClaims(generatedToken.Value(), &jwtClaimsSchema{}, func(token *jwt.Token) (interface{}, error) {
+				return loadSecret(), nil
+			})
+
+			claims, ok := parsedToken.Claims.(*jwtClaimsSchema)
+
+			if ok && parsedToken.Valid {
+				log.Printf("%v %v", claims.AccountId, claims.RegisteredClaims.ExpiresAt)
+			} else {
+				t.Fatal("failed to parse token")
+			}
+
+			if claims.AccountId != tt.want {
+				t.Errorf("got %s expected %s", claims.AccountId, tt.want)
+			}
+		})
+	}
+}

--- a/app/vos/token/token_test.go
+++ b/app/vos/token/token_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
@@ -11,7 +12,7 @@ import (
 	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
 )
 
-func TestGenerateJWT(t *testing.T) {
+func TestSign(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -39,7 +40,7 @@ func TestGenerateJWT(t *testing.T) {
 			generatedToken, err := Sign(tt.id)
 
 			if !errors.Is(err, tt.err) {
-				t.Errorf("got error %s expected error %s", err, tt.err)
+				t.Fatalf("got error %s expected error %s", err, tt.err)
 			}
 
 			parsedToken, _ := jwt.ParseWithClaims(generatedToken.Value(), &jwtClaimsSchema{}, func(token *jwt.Token) (interface{}, error) {
@@ -56,6 +57,100 @@ func TestGenerateJWT(t *testing.T) {
 
 			if claims.AccountId != tt.want {
 				t.Errorf("got %s expected %s", claims.AccountId, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerify(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name  string
+		token string
+		want  string
+		err   error
+	}
+
+	var testId = account.AccountId(uuid.New())
+
+	testCases := []testCase{
+		{
+			name: "successfully verify token",
+			token: func() string {
+				claims := jwtClaimsSchema{
+					testId.String(),
+					jwt.RegisteredClaims{
+						ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 30)),
+						Issuer:    "suricate bank",
+					},
+				}
+
+				unsignedToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+				signedToken, _ := unsignedToken.SignedString(loadSecret())
+
+				return signedToken
+			}(),
+			want: testId.String(),
+		},
+		{
+			name: "fail to verify invalid signature",
+			token: func() string {
+				claims := jwtClaimsSchema{
+					testId.String(),
+					jwt.RegisteredClaims{
+						ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 30)),
+						Issuer:    "suricate bank",
+					},
+				}
+
+				unsignedToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+				signedToken, _ := unsignedToken.SignedString([]byte("wrong signature"))
+
+				return signedToken
+			}(),
+			want: uuid.Nil.String(),
+			err:  ErrJwtSignature,
+		},
+		{
+			name: "fail to verify token missing account_id",
+			token: func() string {
+				claims := jwtClaimsSchema{
+					"",
+					jwt.RegisteredClaims{
+						ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 30)),
+						Issuer:    "suricate bank",
+					},
+				}
+
+				unsignedToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+				signedToken, _ := unsignedToken.SignedString(loadSecret())
+
+				return signedToken
+			}(),
+			want: uuid.Nil.String(),
+			err:  ErrParseUuid,
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			j := Jwt{token: tt.token}
+
+			accountId, err := j.Verify()
+
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("got error %s expected error %s", err, tt.err)
+			}
+
+			if accountId.String() != tt.want {
+				t.Errorf("got %s expected %s", accountId.String(), tt.want)
 			}
 		})
 	}

--- a/app/vos/token/token_test.go
+++ b/app/vos/token/token_test.go
@@ -1,0 +1,3 @@
+package token
+
+//TODO: escrever testes

--- a/app/vos/token/token_test.go
+++ b/app/vos/token/token_test.go
@@ -141,9 +141,7 @@ func TestVerify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			j := Jwt{token: tt.token}
-
-			accountId, err := j.Verify()
+			accountId, err := Verify(tt.token)
 
 			if !errors.Is(err, tt.err) {
 				t.Fatalf("got error %s expected error %s", err, tt.err)

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
@@ -36,6 +37,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.9.1 // indirect
 	github.com/jackc/puddle v1.2.0 // indirect
+	github.com/joho/godotenv v1.4.0
 	github.com/lib/pq v1.10.4 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.9.1 // indirect
 	github.com/jackc/puddle v1.2.0 // indirect
-	github.com/joho/godotenv v1.4.0
 	github.com/lib/pq v1.10.4 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,13 @@ module github.com/jpgsaraceni/suricate-bank
 go 1.17
 
 require (
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/google/uuid v1.3.0
+	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgx/v4 v4.14.1
+	github.com/ory/dockertest/v3 v3.8.1
+	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e
-)
-
-require (
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.0 // indirect
-	go.uber.org/atomic v1.6.0 // indirect
 )
 
 require (
@@ -25,12 +23,12 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
@@ -43,12 +41,11 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
-	github.com/ory/dockertest/v3 v3.8.1
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sirupsen/logrus v1.8.1
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-migrate/migrate/v4 v4.15.1 h1:Sakl3Nm6+wQKq0Q62tpFMi5a503bgGhceo2icrgQ9vM=
 github.com/golang-migrate/migrate/v4 v4.15.1/go.mod h1:/CrBenUbcDqsW29jGTR/XFqCfVi/Y6mHXlooCcSOJMQ=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
@@ -633,6 +635,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/go.sum
+++ b/go.sum
@@ -635,8 +635,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
-github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
-github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
Add and implement GetByCpf in repository, to get account on login request;

Create a token VO, for signing jwt containing account id for login response (will also be used to verify jwt on transfer requests);

Create a service for authenticaiton (not a usecase because login does not belong to domain);

Create login handler;

Minor refacotr on accounts handler removing reduntant error assessment