### PR TITLE
refactor: Create account route

### DIFF
--- a/app/domain/entities/account/repository.go
+++ b/app/domain/entities/account/repository.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Repository interface {
-	Create(ctx context.Context, account *Account) error
+	Create(ctx context.Context, account Account) (Account, error)
 	GetBalance(ctx context.Context, id AccountId) (int, error)
 	Fetch(ctx context.Context) ([]Account, error)
 	GetById(ctx context.Context, id AccountId) (Account, error)

--- a/app/domain/entities/account/repository_mock.go
+++ b/app/domain/entities/account/repository_mock.go
@@ -8,7 +8,7 @@ import (
 )
 
 type MockRepository struct {
-	OnCreate        func(ctx context.Context, account *Account) error
+	OnCreate        func(ctx context.Context, account Account) (Account, error)
 	OnGetBalance    func(ctx context.Context, id AccountId) (int, error)
 	OnFetch         func(ctx context.Context) ([]Account, error)
 	OnGetById       func(ctx context.Context, id AccountId) (Account, error)
@@ -19,7 +19,7 @@ type MockRepository struct {
 
 var _ Repository = (*MockRepository)(nil)
 
-func (mock MockRepository) Create(ctx context.Context, account *Account) error {
+func (mock MockRepository) Create(ctx context.Context, account Account) (Account, error) {
 	return mock.OnCreate(ctx, account)
 }
 

--- a/app/domain/usecases/account/create_account.go
+++ b/app/domain/usecases/account/create_account.go
@@ -8,32 +8,8 @@ import (
 	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
 )
 
-const (
-	minNameLength = 3
-	maxNameLength = 100
-
-	minPasswordLength = 6
-)
-
-func (uc usecase) Create(ctx context.Context, name, cpf, secret string) (account.Account, error) {
-	if len(name) < minNameLength || len(name) > maxNameLength {
-
-		return account.Account{}, ErrNameLength
-	}
-
-	if len(secret) < minPasswordLength {
-
-		return account.Account{}, ErrShortSecret
-	}
-
-	newAccount, err := account.NewAccount(name, cpf, secret)
-
-	if err != nil {
-
-		return account.Account{}, fmt.Errorf("failed to create account instance: %w", err)
-	}
-
-	err = uc.repository.Create(ctx, &newAccount)
+func (uc usecase) Create(ctx context.Context, accountInstance account.Account) (account.Account, error) {
+	persistedAccount, err := uc.repository.Create(ctx, accountInstance)
 
 	if err != nil {
 		if errors.Is(err, account.ErrDuplicateCpf) {
@@ -44,5 +20,5 @@ func (uc usecase) Create(ctx context.Context, name, cpf, secret string) (account
 		return account.Account{}, fmt.Errorf("%w: %s", ErrRepository, err.Error())
 	}
 
-	return newAccount, nil
+	return persistedAccount, nil
 }

--- a/app/domain/usecases/account/usecase.go
+++ b/app/domain/usecases/account/usecase.go
@@ -12,7 +12,7 @@ type usecase struct {
 }
 
 type Usecase interface {
-	Create(ctx context.Context, name, cpf, secret string) (account.Account, error)
+	Create(ctx context.Context, accountInstance account.Account) (account.Account, error)
 	GetBalance(ctx context.Context, id account.AccountId) (int, error)
 	Fetch(ctx context.Context) ([]account.Account, error)
 }

--- a/app/domain/usecases/account/usecase_mock.go
+++ b/app/domain/usecases/account/usecase_mock.go
@@ -7,15 +7,15 @@ import (
 )
 
 type MockUsecase struct {
-	OnCreate     func(ctx context.Context, name, cpf, secret string) (account.Account, error)
+	OnCreate     func(ctx context.Context, accountInstance account.Account) (account.Account, error)
 	OnGetBalance func(ctx context.Context, id account.AccountId) (int, error)
 	OnFetch      func(ctx context.Context) ([]account.Account, error)
 }
 
 var _ Usecase = (*MockUsecase)(nil)
 
-func (mock MockUsecase) Create(ctx context.Context, name, cpf, secret string) (account.Account, error) {
-	return mock.OnCreate(ctx, name, cpf, secret)
+func (mock MockUsecase) Create(ctx context.Context, accountInstance account.Account) (account.Account, error) {
+	return mock.OnCreate(ctx, accountInstance)
 }
 
 func (mock MockUsecase) GetBalance(ctx context.Context, id account.AccountId) (int, error) {

--- a/app/gateways/api/http/handlers/accounts/create.go
+++ b/app/gateways/api/http/handlers/accounts/create.go
@@ -21,37 +21,15 @@ func (h handler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if createRequest.Name == "" || createRequest.Cpf == "" || createRequest.Secret == "" {
-		response.BadRequest(responses.ErrMissingFieldsAccountPayload).SendJSON()
+	accountInstance, response := createRequest.Validate(response)
+
+	if response.IsComplete() {
+		response.SendJSON()
 
 		return
 	}
 
-	cpf := createRequest.Cpf
-
-	if len(cpf) != 11 && len(cpf) != 14 {
-		response.BadRequest(responses.ErrLengthCpf).SendJSON()
-
-		return
-	}
-
-	name := createRequest.Name
-
-	if len(name) < 3 {
-		response.BadRequest(responses.ErrShortName).SendJSON()
-
-		return
-	}
-
-	secret := createRequest.Secret
-
-	if len(secret) < 6 {
-		response.BadRequest(responses.ErrShortSecret).SendJSON()
-
-		return
-	}
-
-	createdAccount, err := h.usecase.Create(r.Context(), name, cpf, secret)
+	persistedAccount, err := h.usecase.Create(r.Context(), accountInstance)
 
 	if errors.Is(err, account.ErrInvalidCpf) {
 		response.BadRequest(responses.ErrInvalidCpf).SendJSON()
@@ -71,5 +49,5 @@ func (h handler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response.Created(schemas.CreatedAccountToResponse(createdAccount)).SendJSON()
+	response.Created(schemas.CreatedAccountToResponse(persistedAccount)).SendJSON()
 }

--- a/app/gateways/api/http/handlers/accounts/create_test.go
+++ b/app/gateways/api/http/handlers/accounts/create_test.go
@@ -55,7 +55,7 @@ func TestCreate(t *testing.T) {
 				w: httptest.NewRecorder(),
 			},
 			usecase: accountuc.MockUsecase{
-				OnCreate: func(ctx context.Context, name, cpf, secret string) (account.Account, error) {
+				OnCreate: func(ctx context.Context, accountInstance account.Account) (account.Account, error) {
 					return testAccount, nil
 				},
 			},
@@ -108,7 +108,7 @@ func TestCreate(t *testing.T) {
 				w: httptest.NewRecorder(),
 			},
 			expectedStatus:  400,
-			expectedPayload: map[string]interface{}{"title": responses.ErrShortName.Payload.Message},
+			expectedPayload: map[string]interface{}{"title": responses.ErrLengthName.Payload.Message},
 		},
 		{
 			name: "respond 400 to request with missing cpf",
@@ -150,7 +150,7 @@ func TestCreate(t *testing.T) {
 				w: httptest.NewRecorder(),
 			},
 			usecase: accountuc.MockUsecase{
-				OnCreate: func(ctx context.Context, name, cpf, secret string) (account.Account, error) {
+				OnCreate: func(ctx context.Context, accountInstance account.Account) (account.Account, error) {
 					return account.Account{}, account.ErrInvalidCpf
 				},
 			},
@@ -197,7 +197,7 @@ func TestCreate(t *testing.T) {
 				w: httptest.NewRecorder(),
 			},
 			usecase: accountuc.MockUsecase{
-				OnCreate: func(ctx context.Context, name, cpf, secret string) (account.Account, error) {
+				OnCreate: func(ctx context.Context, accountInstance account.Account) (account.Account, error) {
 					return account.Account{}, account.ErrDuplicateCpf
 				},
 			},
@@ -216,7 +216,7 @@ func TestCreate(t *testing.T) {
 				w: httptest.NewRecorder(),
 			},
 			usecase: accountuc.MockUsecase{
-				OnCreate: func(ctx context.Context, name, cpf, secret string) (account.Account, error) {
+				OnCreate: func(ctx context.Context, accountInstance account.Account) (account.Account, error) {
 					return account.Account{}, accountuc.ErrRepository
 				},
 			},

--- a/app/gateways/api/http/responses/payloads.go
+++ b/app/gateways/api/http/responses/payloads.go
@@ -30,9 +30,9 @@ var (
 		Err:     errors.New("invalid cpf length"),
 		Payload: ErrorPayload{Message: "CPF must contain 11 numeric digits or 14 digits including 3 symbols"},
 	}
-	ErrShortName = Error{
-		Err:     errors.New("name too short"),
-		Payload: ErrorPayload{Message: "Name must have at least 3 digits"},
+	ErrLengthName = Error{
+		Err:     errors.New("invalid name length"),
+		Payload: ErrorPayload{Message: "Name must have from 3 to 100 digits"},
 	}
 	ErrShortSecret = Error{
 		Err:     errors.New("secret too short"),

--- a/app/gateways/api/http/schemas/create_account.go
+++ b/app/gateways/api/http/schemas/create_account.go
@@ -1,9 +1,11 @@
 package schemas
 
 import (
+	"errors"
 	"time"
 
 	"github.com/jpgsaraceni/suricate-bank/app/domain/entities/account"
+	"github.com/jpgsaraceni/suricate-bank/app/gateways/api/http/responses"
 )
 
 type CreateAccountRequest struct {
@@ -28,4 +30,49 @@ func CreatedAccountToResponse(createdAccount account.Account) CreateAccountRespo
 		Balance:   createdAccount.Balance.BRL(),
 		CreatedAt: createdAccount.CreatedAt,
 	}
+}
+
+const (
+	minNameLength = 3
+	maxNameLength = 100
+
+	minSecretLength = 6
+
+	rawCpfLength    = 11
+	maskedCpfLength = 14
+)
+
+func (r CreateAccountRequest) Validate(response responses.Response) (account.Account, responses.Response) {
+	if r.Name == "" || r.Cpf == "" || r.Secret == "" {
+
+		return account.Account{}, response.BadRequest(responses.ErrMissingFieldsAccountPayload)
+	}
+
+	if len(r.Name) < minNameLength || len(r.Name) > maxNameLength {
+
+		return account.Account{}, response.BadRequest(responses.ErrLengthName)
+	}
+
+	if len(r.Secret) < minSecretLength {
+
+		return account.Account{}, response.BadRequest(responses.ErrShortSecret)
+	}
+
+	if len(r.Cpf) != rawCpfLength && len(r.Cpf) != maskedCpfLength {
+
+		return account.Account{}, response.BadRequest(responses.ErrLengthCpf)
+	}
+
+	accountInstance, err := account.NewAccount(r.Name, r.Cpf, r.Secret)
+
+	if err != nil {
+		if errors.Is(err, account.ErrInvalidCpf) {
+
+			return account.Account{}, response.BadRequest(responses.ErrInvalidCpf)
+		}
+
+		return account.Account{}, response.InternalServerError(err)
+	}
+
+	return accountInstance, response
 }


### PR DESCRIPTION
Validate create account request in schema and create instance;

Changed usecase and repository signatures to receive copy of account instance instead of pointer;

Return persisted account from repository and usecase.